### PR TITLE
DarrenS: Load profile image (basic version)

### DIFF
--- a/src/main/resources/templates/profile.ftl
+++ b/src/main/resources/templates/profile.ftl
@@ -8,7 +8,7 @@
 <#else>
 	<div class="page-content-750-1000">
 		<table class="profile-box">
-		<tr><td style="width: 35%;"><img class="profile-image" src="/images/profileNeutral.png"></td>
+		<tr><td style="width: 35%;"><img id="profile-picture" class="profile-image" src="/images/profileNeutral.png"></td>
 			<td>
 				<div class="profile-basic-stats">
 					<div class="h1-like" id="display-name"></div>

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -521,6 +521,8 @@ table.openings-calendar div.highlight {
 	margin-top: 2rem;
 	margin-left: 3rem;
 	width: 100%;
+	height: 30rem;
+    object-fit: cover;
 }
 .profile-basic-stats {
 	width: 90%;

--- a/src/main/webapp/scripts/profileOperations.js
+++ b/src/main/webapp/scripts/profileOperations.js
@@ -1,4 +1,9 @@
 
+window.onload = _ => {
+	populateData();
+	tryReplaceProfilePicture();
+}
+
 const parseQuery = (queryString) => {
 	if (typeof queryString !== 'string') return {};
 	if (queryString.charAt(0) === '?') queryString = queryString.substring(1);
@@ -51,8 +56,22 @@ const populateData = async _ => {
 	}
 	refreshAll();
 };
-populateData();
 
+const tryReplaceProfilePicture = async _ => {
+	if (!memberId) return; // obtained during page load process
+	try {
+		const response = await fetch('/custom/profiles/u' + memberId + '/profile.png');
+
+		if (!response.ok) throw new Error('User does not appear to have a profile image yet.')
+		
+		// This should automatically refresh 
+		profilePicture.src = '/custom/profiles/u' + memberId + '/profile.png';
+	} catch (err) {
+		console.log(err.message);
+	}
+};
+
+const profilePicture = document.getElementById('profile-picture');
 const displayNameBox = document.getElementById('display-name');
 
 const creditsRow = document.getElementById('credits-row');

--- a/src/main/webapp/scripts/profileOperations.js
+++ b/src/main/webapp/scripts/profileOperations.js
@@ -62,7 +62,8 @@ const tryReplaceProfilePicture = async _ => {
 	
 	try {
 		
-		// CacheStorage.has()
+		// TODO: Needs server-side support to avoid error spam.
+		//       Can be addressed in issue to "make secure".
 		
 		// TRY ".png"
 		let imagePath = '/custom/profiles/u' + memberId + '/profile.png';
@@ -77,6 +78,14 @@ const tryReplaceProfilePicture = async _ => {
 		imagePath = '/custom/profiles/u' + memberId + '/profile.jpg';
 		const response2 = await fetch(imagePath);
 		if (response2.ok) {
+			profilePicture.src = imagePath;
+			return;
+		}
+		
+		// TRY ".gif"
+		imagePath = '/custom/profiles/u' + memberId + '/profile.gif';
+		const response3 = await fetch(imagePath);
+		if (response3.ok) {
 			profilePicture.src = imagePath;
 			return;
 		}

--- a/src/main/webapp/scripts/profileOperations.js
+++ b/src/main/webapp/scripts/profileOperations.js
@@ -59,15 +59,31 @@ const populateData = async _ => {
 
 const tryReplaceProfilePicture = async _ => {
 	if (!memberId) return; // obtained during page load process
+	
 	try {
-		const response = await fetch('/custom/profiles/u' + memberId + '/profile.png');
-
-		if (!response.ok) throw new Error('User does not appear to have a profile image yet.')
 		
-		// This should automatically refresh 
-		profilePicture.src = '/custom/profiles/u' + memberId + '/profile.png';
+		// CacheStorage.has()
+		
+		// TRY ".png"
+		let imagePath = '/custom/profiles/u' + memberId + '/profile.png';
+		const response1 = await fetch(imagePath);
+		if (response1.ok) {
+			// Will automatically refresh with cached data
+			profilePicture.src = imagePath;
+			return;
+		}
+		
+		// TRY ".jpg"
+		imagePath = '/custom/profiles/u' + memberId + '/profile.jpg';
+		const response2 = await fetch(imagePath);
+		if (response2.ok) {
+			profilePicture.src = imagePath;
+			return;
+		}
+
+		console.log('User does not exist or does not have a profile image.');
 	} catch (err) {
-		console.log(err.message);
+		// do nothing
 	}
 };
 


### PR DESCRIPTION
Pulls directly from "custom" folder.
This is insecure because it doesn't check for user access to view said image prior providing said data, yet the "regular method" of including the picture in the source doesn't work so it'll need its own process, similar to the /custom/ process, but designed just for image provision. That will also squelch any "error" message spam that occurs while it attempts to see if certain files exist or not.